### PR TITLE
Modernize stack, add nap schedule + age-based recommendations

### DIFF
--- a/src/models/ScheduleSetting.test.ts
+++ b/src/models/ScheduleSetting.test.ts
@@ -167,6 +167,12 @@ describe('ScheduleSetting', () => {
             // chronological 0 weeks, minus 10 weeks = -10 -> clamped to 0
             expect(ss.weeksSinceBirth).toBe(0);
         });
+
+        it('should return 0 (not NaN) for an empty birthday', () => {
+            const ss = new ScheduleSetting();
+            ss.birthdayDate = ""; // user cleared the date field
+            expect(ss.weeksSinceBirth).toBe(0);
+        });
     });
 
     describe('monthsSinceBirth', () => {
@@ -200,6 +206,12 @@ describe('ScheduleSetting', () => {
             const ss = new ScheduleSetting();
             ss.weeks = 40;
             ss.birthdayDate = "2024-06-15"; // future
+            expect(ss.monthsSinceBirth).toBe(0);
+        });
+
+        it('should return 0 (not NaN) for an empty birthday', () => {
+            const ss = new ScheduleSetting();
+            ss.birthdayDate = ""; // user cleared the date field
             expect(ss.monthsSinceBirth).toBe(0);
         });
     });

--- a/src/models/ScheduleSetting.ts
+++ b/src/models/ScheduleSetting.ts
@@ -36,6 +36,7 @@ class ScheduleSetting {
 
     /** Adjusted age in weeks, accounting for gestational age (premature babies get a younger adjusted age). */
     public get weeksSinceBirth(): number {
+        if (isNaN(this.birthday.getTime())) return 0; // no/invalid birthday entered yet
         const msInWeek = 1000 * 60 * 60 * 24 * 7;
         const chronologicalWeeks = (new Date().getTime() - this.birthday.getTime()) / msInWeek;
         const gestationalAdjustment = 40 - this.weeks;
@@ -44,6 +45,7 @@ class ScheduleSetting {
 
     /** Adjusted age in months, accounting for gestational age. */
     public get monthsSinceBirth(): number {
+        if (isNaN(this.birthday.getTime())) return 0; // no/invalid birthday entered yet
         const chronologicalMonths =
             (new Date().getFullYear() - this.birthday.getFullYear()) * 12
             + new Date().getMonth() - this.birthday.getMonth();

--- a/src/models/ScheduleSetting.ts
+++ b/src/models/ScheduleSetting.ts
@@ -36,19 +36,21 @@ class ScheduleSetting {
 
     /** Adjusted age in weeks, accounting for gestational age (premature babies get a younger adjusted age). */
     public get weeksSinceBirth(): number {
-        if (isNaN(this.birthday.getTime())) return 0; // no/invalid birthday entered yet
+        const birthMs = this.birthday.getTime();
+        if (Number.isNaN(birthMs)) return 0; // no/invalid birthday entered yet
         const msInWeek = 1000 * 60 * 60 * 24 * 7;
-        const chronologicalWeeks = (new Date().getTime() - this.birthday.getTime()) / msInWeek;
+        const chronologicalWeeks = (Date.now() - birthMs) / msInWeek;
         const gestationalAdjustment = 40 - this.weeks;
         return Math.max(0, Math.round(chronologicalWeeks - gestationalAdjustment));
     }
 
     /** Adjusted age in months, accounting for gestational age. */
     public get monthsSinceBirth(): number {
-        if (isNaN(this.birthday.getTime())) return 0; // no/invalid birthday entered yet
+        if (Number.isNaN(this.birthday.getTime())) return 0; // no/invalid birthday entered yet
+        const now = new Date();
         const chronologicalMonths =
-            (new Date().getFullYear() - this.birthday.getFullYear()) * 12
-            + new Date().getMonth() - this.birthday.getMonth();
+            (now.getFullYear() - this.birthday.getFullYear()) * 12
+            + now.getMonth() - this.birthday.getMonth();
         const gestationalAdjustmentMonths = Math.round((40 - this.weeks) / 4.345);
         const adjusted = chronologicalMonths - gestationalAdjustmentMonths;
         return adjusted <= 0 ? 0 : adjusted;


### PR DESCRIPTION
## Summary

Brings the feature branch up for review. Modernizes the build/stack, fixes a batch of scheduling bugs, and adds age-aware sleep recommendations with a nap schedule and responsive layout.

## What's in here
- **Stack modernization** — Vue 3.5 / Vite 6 / TS 5.9 / Tailwind v4 (via `@tailwindcss/vite`, no PostCSS config), Vitest 4. Netlify deploy fixed (Node 20).
- **Scheduling fixes** — corrected the flipped night-sleep sign and its follow-ons; `naps` getter now used in validation; `currentBracket` typed nullable with duplicate out-of-range messaging removed.
- **Recommendations** — age-bracketed guidance from multiple sources (Twins/Triplets/Quads, Huckleberry, AAP/Sleep Foundation), each cited with external links; reorganized comparison UI.
- **Nap schedule + layout** — evenly-split nap clock times between wake windows; responsive two-column layout.
- **NaN fix (latest)** — clearing the birthday field produced an Invalid Date, so the age getters returned `NaN` (`Math.max(0, NaN)` is `NaN`), cascading to "NaN weeks / NaN months" and "No guidance for NaN months". Both getters now return `0` for an empty/invalid birthday, with regression tests.

## Testing
- `npm test` — 49 passing (includes new empty-birthday cases).
- Verified in the browser: clearing the birthday now shows "0 weeks / 0 months", no `NaN` on the page, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Age calculation methods now reliably handle edge cases, including empty birthday values, and return correct results instead of unexpected values.
  * Optimized internal performance of age computations.

* **Tests**
  * Added test coverage for age calculation edge cases to ensure accurate results under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->