### PR TITLE
Fix WCAG 2.2 AA accessibility gaps across the UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,10 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="png" href="/src/assets/logo.png" />
+  <link rel="icon" type="image/png" href="/src/assets/logo.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wake Windows Guru</title>
+  <meta name="description" content="Plan an infant's nap schedule from wake windows, age, and bedtime — checked against cited sleep guidance." />
+  <title>Wake Windows — Infant Nap Schedule Planner</title>
 </head>
 
 <body class="bg-slate-900 h-full">

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@ import { meta } from './models/Citations'
 
     <Summary />
 
-    <footer class="mt-8 border-t border-slate-800 pt-3 pb-6 text-slate-500 text-xs">
+    <footer class="mt-8 border-t border-slate-800 pt-3 pb-6 text-muted text-xs">
       <p>{{ meta.disclaimer }}</p>
       <p class="mt-1">Guidance last reviewed: {{ meta.lastVerified }}.</p>
     </footer>

--- a/src/components/EvidenceGuidance.vue
+++ b/src/components/EvidenceGuidance.vue
@@ -33,7 +33,7 @@ function toggle(i: number) {
                                    <TierBadge :tier="item.tier" />
                               </div>
                               <div class="text-slate-200 text-sm">{{ item.value }}</div>
-                              <p v-if="item.note" class="text-slate-500 text-xs mt-0.5">{{ item.note }}</p>
+                              <p v-if="item.note" class="text-muted text-xs mt-0.5">{{ item.note }}</p>
                          </div>
                          <button
                               type="button"
@@ -45,7 +45,7 @@ function toggle(i: number) {
                          </button>
                     </div>
 
-                    <div v-if="open[i]" class="mt-2 space-y-2 pl-2 border-l-2 border-slate-800">
+                    <div v-if="open[i]" class="mt-2 space-y-2 pl-3">
                          <div
                               v-for="src in getSources(item.sourceIds)"
                               :key="src.id"
@@ -53,18 +53,18 @@ function toggle(i: number) {
                          >
                               <div class="flex flex-wrap items-center gap-2">
                                    <TierBadge :tier="src.tier" />
-                                   <span class="text-slate-500 uppercase tracking-wide">{{ src.type }}</span>
-                                   <span class="text-slate-500">{{ src.year }}</span>
+                                   <span class="text-muted uppercase tracking-wide">{{ src.type }}</span>
+                                   <span class="text-muted">{{ src.year }}</span>
                               </div>
                               <a
                                    :href="src.url"
                                    target="_blank"
                                    rel="noopener noreferrer"
                                    class="text-sky-400 hover:text-sky-300 underline underline-offset-2"
-                              >{{ src.title }} <span aria-hidden="true" class="text-slate-500">↗</span></a>
+                              >{{ src.title }} <span aria-hidden="true" class="text-muted">↗</span></a>
                               <div class="text-slate-400">{{ src.org }} · {{ src.venue }}</div>
                               <p class="text-slate-400 mt-0.5">{{ src.credentials }}</p>
-                              <p class="text-slate-500 mt-0.5">{{ src.summary }}</p>
+                              <p class="text-muted mt-0.5">{{ src.summary }}</p>
                          </div>
                     </div>
                </li>

--- a/src/components/Recommendations.vue
+++ b/src/components/Recommendations.vue
@@ -59,19 +59,19 @@ function inRange(row: Row): boolean {
             <div class="flex items-baseline justify-between gap-3">
                 <h3 class="text-slate-300 text-sm font-semibold flex flex-wrap items-center gap-2">
                     <a v-if="view.url" :href="view.url" target="_blank" rel="noopener noreferrer"
-                        class="hover:text-sky-400 underline decoration-slate-600 underline-offset-2">{{ view.name }}
-                        <span aria-hidden="true" class="text-slate-500">↗</span></a>
+                        class="hover:text-sky-400 underline decoration-slate-500 underline-offset-2">{{ view.name }}
+                        <span aria-hidden="true" class="text-muted">↗</span></a>
                     <template v-else>{{ view.name }}</template>
                     <TierBadge :tier="view.tier" />
                 </h3>
-                <span v-if="view.range" class="text-slate-500 text-xs whitespace-nowrap">
+                <span v-if="view.range" class="text-muted text-xs whitespace-nowrap">
                     {{ view.range }} · age {{ view.months }} mo
                 </span>
             </div>
 
             <table v-if="view.rows.length" class="w-full text-sm mt-1">
                 <thead>
-                    <tr class="text-slate-500 text-xs">
+                    <tr class="text-muted text-xs">
                         <th class="text-left font-normal"></th>
                         <th class="text-right font-normal w-16">You</th>
                         <th class="text-right font-normal w-24">Range</th>
@@ -93,7 +93,7 @@ function inRange(row: Row): boolean {
                     </tr>
                 </tbody>
             </table>
-            <p v-else class="text-slate-500 text-sm mt-1">
+            <p v-else class="text-muted text-sm mt-1">
                 No guidance for {{ view.months }} months in this source.
             </p>
 

--- a/src/components/SafeSleep.vue
+++ b/src/components/SafeSleep.vue
@@ -28,7 +28,7 @@ const sources = getSources(['aap-safesleep-2022', 'nichd-safetosleep', 'lullaby-
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-sky-400 hover:text-sky-300 underline underline-offset-2"
-               >{{ src.org }} <span aria-hidden="true" class="text-slate-500">↗</span></a>
+               >{{ src.org }} <span aria-hidden="true" class="text-muted">↗</span></a>
           </div>
      </div>
 </template>

--- a/src/components/SourcesEvidence.vue
+++ b/src/components/SourcesEvidence.vue
@@ -19,7 +19,7 @@ const byTier = computed(() =>
      <details class="rounded border border-slate-800">
           <summary class="cursor-pointer select-none px-3 py-2 text-slate-300 text-sm font-semibold">
                Sources &amp; Evidence
-               <span class="text-slate-500 font-normal">— {{ sources.length }} citations, by tier</span>
+               <span class="text-muted font-normal">— {{ sources.length }} citations, by tier</span>
           </summary>
 
           <div class="px-3 pb-3 space-y-5">
@@ -29,9 +29,9 @@ const byTier = computed(() =>
                     <div v-for="t in [tiers['1'], tiers['2']]" :key="t.id" class="text-xs">
                          <TierBadge :tier="t.id" />
                          <p class="text-slate-400 mt-1">{{ t.description }}</p>
-                         <p class="text-slate-500 mt-0.5"><span class="text-slate-400">Applies to:</span> {{ t.appliesTo }}</p>
+                         <p class="text-muted mt-0.5"><span class="text-slate-400">Applies to:</span> {{ t.appliesTo }}</p>
                     </div>
-                    <p class="text-slate-500 text-xs italic">
+                    <p class="text-muted text-xs italic">
                          No randomized trial, cohort study, or systematic review validates specific wake-window
                          durations; the term does not appear in the pediatric sleep-medicine literature. Independent
                          medical sources publish wider ranges than consultant brands — a reminder the exact numbers are
@@ -43,26 +43,26 @@ const byTier = computed(() =>
                <div v-for="group in byTier" :key="group.tier.id" class="space-y-3">
                     <div class="flex items-center gap-2 border-t border-slate-800 pt-3">
                          <TierBadge :tier="group.tier.id" />
-                         <span class="text-slate-500 text-xs">{{ group.sources.length }} sources</span>
+                         <span class="text-muted text-xs">{{ group.sources.length }} sources</span>
                     </div>
                     <div v-for="src in group.sources" :key="src.id" class="text-xs">
                          <div class="flex flex-wrap items-center gap-2">
-                              <span class="text-slate-500 uppercase tracking-wide">{{ src.type }}</span>
-                              <span class="text-slate-500">{{ src.year }}</span>
+                              <span class="text-muted uppercase tracking-wide">{{ src.type }}</span>
+                              <span class="text-muted">{{ src.year }}</span>
                          </div>
                          <a
                               :href="src.url"
                               target="_blank"
                               rel="noopener noreferrer"
                               class="text-sky-400 hover:text-sky-300 underline underline-offset-2"
-                         >{{ src.title }} <span aria-hidden="true" class="text-slate-500">↗</span></a>
+                         >{{ src.title }} <span aria-hidden="true" class="text-muted">↗</span></a>
                          <div class="text-slate-400">{{ src.org }} · {{ src.venue }}</div>
                          <p class="text-slate-400 mt-0.5">{{ src.credentials }}</p>
-                         <p class="text-slate-500 mt-0.5">{{ src.summary }}</p>
+                         <p class="text-muted mt-0.5">{{ src.summary }}</p>
                     </div>
                </div>
 
-               <p class="text-slate-600 text-xs border-t border-slate-800 pt-2">
+               <p class="text-muted text-xs border-t border-slate-800 pt-2">
                     Guidance last reviewed: {{ meta.lastVerified }}
                </p>
           </div>

--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -114,14 +114,17 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
 
       <span class="text-gray-400 text-sm">Wake Windows</span>
       <div class="mb-4">
-        <div v-for="(find, index) in schedule.wws">
-          <input type="number" class="bg-slate-800 text-gray-300 text-sm rounded p-2.5 mb-1" placeholder="Hours"
-            v-model="schedule.wws[index]" min="0" max="6" step="0.25" />
-          <button class="bg-slate-800 text-gray-300 text-sm rounded block p-2.5 mb-1 float-right"
-            v-on:click="removeWW(index)">-</button>
-
+        <div v-for="(find, index) in schedule.wws" class="flex items-center gap-2 mb-1">
+          <input type="number" class="bg-slate-800 text-gray-300 text-sm rounded p-2.5 min-h-11" placeholder="Hours"
+            v-model="schedule.wws[index]" min="0" max="6" step="0.25" :aria-label="`Wake window ${index + 1} (hours)`" />
+          <button type="button"
+            class="inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-gray-300 text-lg rounded min-h-11 min-w-11 disabled:opacity-40 disabled:cursor-not-allowed"
+            :disabled="schedule.wws.length <= 1" :aria-label="`Remove wake window ${index + 1}`"
+            v-on:click="removeWW(index)">−</button>
         </div>
-        <button class="bg-slate-800 text-gray-300 text-sm rounded block p-2.5 mb-1" v-on:click="addWW">+</button>
+        <button type="button"
+          class="inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-gray-300 text-lg rounded min-h-11 min-w-11"
+          aria-label="Add wake window" v-on:click="addWW">+</button>
       </div>
 
       <span class="text-gray-400 text-sm">Bedtime</span>
@@ -161,7 +164,7 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
           <span class="text-slate-400 text-sm uppercase">Summary</span>
 
           <div class="text-xl">
-            <strong>{{ schedule.dwt }}</strong>-<span v-for="(find, index) in schedule.wws" class="text-gray-600">
+            <strong>{{ schedule.dwt }}</strong>-<span v-for="(find, index) in schedule.wws" class="text-muted">
               <span v-if="find" class="text-gray-200">{{ find }}</span><span
                 v-if="index != schedule.wws.length - 1">/</span></span>-<strong>{{ schedule.bed }}</strong>
           </div>
@@ -177,21 +180,21 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
         <div class="bg-orange-500 rounded-l-lg text-right inline-block h-10 overflow-hidden"
           :style="{ width: `${(schedule.totalWakeTime / 24) * 100}%` }">
           <img src="/src/assets/sun.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2">
+          <span class="text-xl m-2 text-slate-900 font-semibold">
             {{ schedule.totalWakeTime }}h</span>
         </div>
 
         <div class="bg-cyan-500 text-right inline-block h-10 overflow-hidden"
           :style="{ width: `${(schedule.totalNightSleep / 24) * 100}%` }">
           <img src="/src/assets/moon.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2">
+          <span class="text-xl m-2 text-slate-900 font-semibold">
             {{ schedule.totalNightSleep }}h</span>
         </div>
 
         <div class="bg-violet-500 rounded-r-lg  text-right h-10 inline-block overflow-hidden"
           :style="{ width: `${(schedule.totalNap / 24) * 100}%` }">
           <img src="/src/assets/sleeping-baby2.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2">
+          <span class="text-xl m-2 text-slate-900 font-semibold">
             {{ schedule.totalNap }}h</span>
         </div>
       </div>
@@ -264,7 +267,7 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
 
       <div class="mt-6">
         <span class="text-slate-400 text-sm uppercase">How your plan compares</span>
-        <p class="text-slate-500 text-xs mb-2">
+        <p class="text-muted text-xs mb-2">
           Total-sleep and nap counts are evidence-based (Tier 1). Wake-window timing is a practice-based
           heuristic (Tier 2) — a starting estimate, not a rule. Watch your baby's tiredness cues over the clock.
         </p>

--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -63,29 +63,26 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
 </script>
 
 <template>
-  <div class="grid grid-cols-[30%_70%] w-full">
-    <img class="h-20" src="/src/assets/logo.png" alt="Wake Windows">
-  </div>
+  <img class="h-20 mb-2" src="/src/assets/logo.png" alt="Wake Windows">
 
-  <div class="grid grid-cols-1 gap-6 md:grid-cols-[30%_70%] w-full md:h-64">
+
+  <div class="grid grid-cols-1 gap-6 md:grid-cols-[30%_70%] w-full md:items-start">
 
     <div class="pr-2">
 
-      <span class="text-gray-400 text-sm">Birthday</span>
-
+      <label for="bd" class="block text-slate-400 text-sm mb-1">Birthday</label>
       <div class="mb-4">
-        <input type="date" class="peer bg-slate-800  text-gray-300 text-sm rounded block p-2.5 mb-1 w-full "
-          placeholder="WW1" v-model="schedule.birthdayDate" required="true" />
-        <span class="hidden peer-invalid:block text-amber-100 text-sm">please enter a birthdate</span>
+        <input id="bd" type="date" class="peer bg-slate-800 text-slate-200 text-sm rounded block p-2.5 w-full"
+          v-model="schedule.birthdayDate" required />
+        <span class="hidden peer-invalid:block text-amber-100 text-sm mt-1">Please enter a birthdate.</span>
       </div>
 
-      <span class="text-gray-400 text-sm">Weeks in Womb</span>
-
-      <input type="number" class="bg-slate-800  text-gray-300 text-sm rounded block p-2.5 mb-1 w-full  mb-4"
+      <label for="weeks" class="block text-slate-400 text-sm mb-1">Weeks in Womb</label>
+      <input id="weeks" type="number" class="bg-slate-800 text-slate-200 text-sm rounded block p-2.5 w-full mb-4"
         placeholder="Weeks" min="20" max="44" step="1" v-model="schedule.weeks" />
 
-      <span class="text-gray-400 text-sm">Desired Wake Time</span>
-      <select class="bg-slate-800 text-gray-300 text-sm block h-8 p-1 w-full mb-4" v-model="schedule.dwt" dir="rtl">
+      <label for="dwt" class="block text-slate-400 text-sm mb-1">Desired Wake Time</label>
+      <select id="dwt" class="bg-slate-800 text-slate-200 text-sm rounded block p-2.5 w-full mb-4" v-model="schedule.dwt" dir="rtl">
         <option value="">12:00</option>
         <option value=".5">12:30</option>
         <option value="1">1:00</option>
@@ -112,24 +109,23 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
         <option value="11.5">11:30</option>
       </select>
 
-      <span class="text-gray-400 text-sm">Wake Windows</span>
-      <div class="mb-4">
+      <span id="ww-label" class="block text-slate-400 text-sm mb-1">Wake Windows</span>
+      <div role="group" aria-labelledby="ww-label" class="mb-4">
         <div v-for="(find, index) in schedule.wws" class="flex items-center gap-2 mb-1">
-          <input type="number" class="bg-slate-800 text-gray-300 text-sm rounded p-2.5 min-h-11" placeholder="Hours"
+          <input type="number" class="bg-slate-800 text-slate-200 text-sm rounded p-2.5 min-h-11 w-full" placeholder="Hours"
             v-model="schedule.wws[index]" min="0" max="6" step="0.25" :aria-label="`Wake window ${index + 1} (hours)`" />
           <button type="button"
-            class="inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-gray-300 text-lg rounded min-h-11 min-w-11 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="shrink-0 inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-slate-300 text-lg rounded min-h-11 min-w-11 disabled:opacity-40 disabled:cursor-not-allowed"
             :disabled="schedule.wws.length <= 1" :aria-label="`Remove wake window ${index + 1}`"
             v-on:click="removeWW(index)">−</button>
         </div>
         <button type="button"
-          class="inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-gray-300 text-lg rounded min-h-11 min-w-11"
+          class="inline-flex items-center justify-center bg-slate-800 hover:bg-slate-700 text-slate-300 text-lg rounded min-h-11 min-w-11"
           aria-label="Add wake window" v-on:click="addWW">+</button>
       </div>
 
-      <span class="text-gray-400 text-sm">Bedtime</span>
-
-      <select class="bg-slate-800 text-gray-300 text-sm rounded block p-2.5 w-full" v-model="schedule.bed" dir="rtl">
+      <label for="bed" class="block text-slate-400 text-sm mb-1">Bedtime</label>
+      <select id="bed" class="bg-slate-800 text-slate-200 text-sm rounded block p-2.5 w-full" v-model="schedule.bed" dir="rtl">
         <option value="">12:00</option>
         <option value=".5">12:30</option>
         <option value="1">1:00</option>
@@ -163,9 +159,9 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
         <div class="basis-1/2">
           <span class="text-slate-400 text-sm uppercase">Summary</span>
 
-          <div class="text-xl">
+          <div class="text-xl tabular-nums">
             <strong>{{ schedule.dwt }}</strong>-<span v-for="(find, index) in schedule.wws" class="text-muted">
-              <span v-if="find" class="text-gray-200">{{ find }}</span><span
+              <span v-if="find" class="text-slate-200">{{ find }}</span><span
                 v-if="index != schedule.wws.length - 1">/</span></span>-<strong>{{ schedule.bed }}</strong>
           </div>
         </div>
@@ -175,27 +171,25 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
         </div>
       </div>
 
-      <div class="block mt-4 h-12">
+      <div class="flex mt-4 h-10" role="img"
+        :aria-label="`Day: ${schedule.totalWakeTime}h awake, ${schedule.totalNightSleep}h night sleep, ${schedule.totalNap}h naps`">
 
-        <div class="bg-orange-500 rounded-l-lg text-right inline-block h-10 overflow-hidden"
+        <div class="bg-orange-500 rounded-l-lg flex items-center justify-between gap-1 px-1.5 overflow-hidden min-w-0"
           :style="{ width: `${(schedule.totalWakeTime / 24) * 100}%` }">
-          <img src="/src/assets/sun.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2 text-slate-900 font-semibold">
-            {{ schedule.totalWakeTime }}h</span>
+          <img src="/src/assets/sun.png" class="h-8 w-8 shrink-0" alt="" aria-hidden="true" />
+          <span class="text-xl text-slate-900 font-semibold tabular-nums">{{ schedule.totalWakeTime }}h</span>
         </div>
 
-        <div class="bg-cyan-500 text-right inline-block h-10 overflow-hidden"
+        <div class="bg-cyan-500 flex items-center justify-between gap-1 px-1.5 overflow-hidden min-w-0"
           :style="{ width: `${(schedule.totalNightSleep / 24) * 100}%` }">
-          <img src="/src/assets/moon.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2 text-slate-900 font-semibold">
-            {{ schedule.totalNightSleep }}h</span>
+          <img src="/src/assets/moon.png" class="h-8 w-8 shrink-0" alt="" aria-hidden="true" />
+          <span class="text-xl text-slate-900 font-semibold tabular-nums">{{ schedule.totalNightSleep }}h</span>
         </div>
 
-        <div class="bg-violet-500 rounded-r-lg  text-right h-10 inline-block overflow-hidden"
+        <div class="bg-violet-500 rounded-r-lg flex items-center justify-between gap-1 px-1.5 overflow-hidden min-w-0"
           :style="{ width: `${(schedule.totalNap / 24) * 100}%` }">
-          <img src="/src/assets/sleeping-baby2.png" class="h-8 w-8 m-1 float-left" alt="" aria-hidden="true" />
-          <span class="text-xl m-2 text-slate-900 font-semibold">
-            {{ schedule.totalNap }}h</span>
+          <img src="/src/assets/sleeping-baby2.png" class="h-8 w-8 shrink-0" alt="" aria-hidden="true" />
+          <span class="text-xl text-slate-900 font-semibold tabular-nums">{{ schedule.totalNap }}h</span>
         </div>
       </div>
 
@@ -212,16 +206,16 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
             <table class="table-auto w-full">
               <tbody>
                 <tr>
-                  <td class="text-gray-400 text-sm uppercase"> Naps ({{ schedule.naps }})</td>
-                  <td>{{ schedule.totalNap }}h</td>
+                  <td class="text-slate-400 text-sm uppercase">Naps ({{ schedule.naps }})</td>
+                  <td class="text-right text-slate-200 tabular-nums">{{ schedule.totalNap }}h</td>
                 </tr>
                 <tr>
-                  <td class="text-gray-400 text-sm uppercase">Night Sleep</td>
-                  <td>{{ schedule.totalNightSleep }}h</td>
+                  <td class="text-slate-400 text-sm uppercase">Night Sleep</td>
+                  <td class="text-right text-slate-200 tabular-nums">{{ schedule.totalNightSleep }}h</td>
                 </tr>
                 <tr class="border-t border-slate-700">
-                  <td class="text-gray-400 text-sm uppercase">Total Sleep</td>
-                  <td>{{ schedule.totalSleep }}h</td>
+                  <td class="text-slate-400 text-sm uppercase">Total Sleep</td>
+                  <td class="text-right text-slate-200 tabular-nums font-medium">{{ schedule.totalSleep }}h</td>
                 </tr>
               </tbody>
             </table>
@@ -230,8 +224,8 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
             <table class="table-auto w-full">
               <tbody>
                 <tr>
-                  <td class="text-gray-400  text-sm  uppercase">Total Wake</td>
-                  <td>{{ schedule.totalWakeTime }}h</td>
+                  <td class="text-slate-400 text-sm uppercase">Total Wake</td>
+                  <td class="text-right text-slate-200 tabular-nums">{{ schedule.totalWakeTime }}h</td>
                 </tr>
               </tbody>
             </table>
@@ -241,19 +235,19 @@ watch([scheduleSummary, () => schedule.birthdayDate], ([shorthand]) => {
 
       <div v-if="schedule.napTimes.length" class="mt-4">
         <span class="text-slate-400 text-sm uppercase">Nap Schedule</span>
-        <div class="flex justify-between text-sm py-1 text-gray-300">
+        <div class="flex justify-between text-sm py-1 text-slate-300">
           <span class="flex items-center gap-2"><img src="/src/assets/sun.png" class="h-5 w-5" alt="" aria-hidden="true" /> Wake</span>
-          <span>{{ formatClock(schedule.wakeMinutes) }}</span>
+          <span class="tabular-nums">{{ formatClock(schedule.wakeMinutes) }}</span>
         </div>
         <div v-for="(nap, i) in schedule.napTimes" :key="i"
-          class="flex justify-between text-sm py-1 border-t border-slate-800 text-gray-300">
+          class="flex justify-between text-sm py-1 border-t border-slate-800 text-slate-300">
           <span class="flex items-center gap-2"><img src="/src/assets/sleeping-baby2.png" class="h-5 w-5" alt="" aria-hidden="true" /> Nap {{ i + 1
             }}</span>
-          <span>{{ formatClock(nap.start) }} – {{ formatClock(nap.end) }}</span>
+          <span class="tabular-nums">{{ formatClock(nap.start) }} – {{ formatClock(nap.end) }}</span>
         </div>
-        <div class="flex justify-between text-sm py-1 border-t border-slate-800 text-gray-300">
+        <div class="flex justify-between text-sm py-1 border-t border-slate-800 text-slate-300">
           <span class="flex items-center gap-2"><img src="/src/assets/moon.png" class="h-5 w-5" alt="" aria-hidden="true" /> Bedtime</span>
-          <span>{{ formatClock(schedule.bedtimeMinutes) }}</span>
+          <span class="tabular-nums">{{ formatClock(schedule.bedtimeMinutes) }}</span>
         </div>
       </div>
 

--- a/src/data/citations.json
+++ b/src/data/citations.json
@@ -11,7 +11,7 @@
       "id": 1,
       "label": "Evidence-based",
       "shortLabel": "Tier 1",
-      "color": "#1a7f4b",
+      "color": "#22a05e",
       "description": "Backed by expert consensus statements and/or peer-reviewed normative data. Reliable population ranges — though still ranges with wide normal variation, not targets every baby must hit.",
       "appliesTo": "Total sleep per 24h, broad nap-count trajectories, sleep-consolidation and circadian-development timelines, safe-sleep practices."
     },

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/* Project tokens layered onto Tailwind v4's theme. `--color-muted` is the
+   accessible muted-text shade: 5.04:1 on the slate-900 body (slate-500 fails
+   AA at 3.75:1), while staying visibly quieter than slate-400 labels. */
+@theme {
+  --color-muted: #7c899e;
+}
+
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
@@ -14,4 +21,41 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+/* Visible focus for every interactive element — sky-400 ring (8.33:1 on the
+   body). Required for WCAG 2.2 AA; native controls shipped without one. */
+:focus-visible {
+  outline: 2px solid var(--color-sky-400, #38bdf8);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Placeholders must clear 4.5:1 too — slate-400 on the slate-800 field. */
+::placeholder {
+  color: var(--color-slate-400, #94a3b8);
+  opacity: 1;
+}
+
+/* Quiet, intentional state motion. Ease-out; state only, never decoration. */
+a,
+button,
+input,
+select,
+summary {
+  transition:
+    color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    outline-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -28,7 +28,6 @@
 :focus-visible {
   outline: 2px solid var(--color-sky-400, #38bdf8);
   outline-offset: 2px;
-  border-radius: 2px;
 }
 
 /* Placeholders must clear 4.5:1 too — slate-400 on the slate-800 field. */


### PR DESCRIPTION
Brings the dark-slate UI to **WCAG 2.2 AA**. Every value below was measured against the `slate-900` body; failures are quoted with their ratios.

## Contrast
- **New `--color-muted` token** (`#7c899e`, 5.04:1) replaces all failing muted text — `slate-500` (3.75:1) and `slate-600`/`gray-600` (2.36:1) are no longer used as text (only decorative underlines/glyphs).
- **Tier 1 badge** brightened `#1a7f4b` (3.55:1) → `#22a05e` (5.32:1) — it failed at the 11px badge size.
- **24-hour bar labels** now dark `slate-900` text; white measured ~2:1 on the orange/cyan segments, now 6.4 / 7.4 / 4.2:1 (large text).

## Focus & input
- **Global `sky-400` `:focus-visible` ring** (8.33:1) on every control — native inputs/selects/buttons had no visible focus indicator.
- Accessible **placeholder** color; **`prefers-reduced-motion`** honored, with quiet 180ms state transitions.

## Targets & semantics
- Wake-window **+/- buttons sized to 44×44px**; `aria-label`s on the window inputs and buttons; remove disables at the last window.
- Replaced the `border-l-2` source-indent **stripe** with plain padding.
- `index.html`: favicon `type="image/png"`, descriptive `<title>`, added `meta description`.

## Verification
- `vue-tsc --noEmit` clean, `vite build` clean, **60/60 Vitest tests pass**.
- Live DOM inspection confirmed each fix (footer `rgb(124,137,158)`, badge `rgb(34,160,94)`, buttons 44×44, bar labels dark, 0 border-l-2, focus-visible rule present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)